### PR TITLE
Add link to API documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python library for eLabFTW REST API.
 
 # Description
 
-This repository allows generating a python library to interact with [eLabFTW](https://github.com/elabftw/elabftw) REST API v2. It uses [Swagger Codegen](https://github.com/swagger-api/swagger-codegen/tree/3.0.0) to generate it based on the OpenApi specification of [eLabFTW](https://github.com/elabftw/elabftw).
+This repository allows generating a python library to interact with [eLabFTW](https://github.com/elabftw/elabftw) REST API v2. It uses [Swagger Codegen](https://github.com/swagger-api/swagger-codegen/tree/3.0.0) to generate it based on the OpenApi specification of [eLabFTW REST API v2](https://doc.elabftw.net/api/v2/).
 
 As such, it doesn't contain the generated code, but only instructions on how to generate it for local development.
 


### PR DESCRIPTION
I changed one of the links in the readme to the API documentation, such that readers might arrive there easily and fast.