### PR TITLE
use swagger-codegen as default generator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,28 @@ From TU Graz, Shared RDM Project:
 
 ## Using the helper script
 
-~~~bash
-# Option 1: generate the library with Swagger codegen
+### Generate the library using Code Generators
+
+The primary tool for generating the library is swagger-codegen. However, you can also use OpenAPI Generator as an alternative, if it better suits your requirements or you encounter issues with the default.
+
+```bash
+# Option 1: Generate using Swagger Codegen
 ./helper.sh generate
-# Option 2: generate using openapi-generator
+
+# Option 2: Generate using OpenAPI Generator
 GENERATOR_TOOL=openapi ./helper.sh generate
-# Option 3: generate from local file: openapi.yaml must be in current dir
+```
+
+### Or Generate from a local OpenAPI Specification
+Ensure the `openapi.yaml` file is located in the current working directory, then run:
+~~~bash
 ./helper.sh generate-from-local
-# build packages
-./helper.sh build
 ~~~
+
+### Build packages
+```bash
+./helper.sh build
+```
 
 ## Installing the library for dev
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python library for eLabFTW REST API.
 
 # Description
 
-This repository allows generating a python library to interact with [eLabFTW](https://github.com/elabftw/elabftw) REST API v2. It uses [Openapi Generator](https://github.com/OpenAPITools/openapi-generator) to generate it based on the OpenApi specification of [eLabFTW REST API v2](https://doc.elabftw.net/api/v2/).
+This repository allows generating a python library to interact with [eLabFTW](https://github.com/elabftw/elabftw) REST API v2. It uses [Swagger Codegen](https://github.com/swagger-api/swagger-codegen/tree/3.0.0) to generate it based on the OpenApi specification of [eLabFTW REST API v2](https://doc.elabftw.net/api/v2/).
 
 As such, it doesn't contain the generated code, but only instructions on how to generate it for local development.
 
@@ -63,9 +63,11 @@ From TU Graz, Shared RDM Project:
 ## Using the helper script
 
 ~~~bash
-# generate the library
+# Option 1: generate the library with Swagger codegen
 ./helper.sh generate
-# generate from local file: openapi.yaml must be in current dir
+# Option 2: generate using openapi-generator
+GENERATOR_TOOL=openapi ./helper.sh generate
+# Option 3: generate from local file: openapi.yaml must be in current dir
 ./helper.sh generate-from-local
 # build packages
 ./helper.sh build

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Python library for eLabFTW REST API.
 
 This repository allows generating a python library to interact with [eLabFTW](https://github.com/elabftw/elabftw) REST API v2. It uses [Swagger Codegen](https://github.com/swagger-api/swagger-codegen/tree/3.0.0) to generate it based on the OpenApi specification of [eLabFTW REST API v2](https://doc.elabftw.net/api/v2/).
 
+Alternatively, it supports using [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) as an optional code generation tool.
+
 As such, it doesn't contain the generated code, but only instructions on how to generate it for local development.
 
 Users should install the library with `pip` or any other python dependency management tool, as described below.

--- a/helper.sh
+++ b/helper.sh
@@ -4,11 +4,22 @@
 # Edit docker systemd service file and add "--default-ulimit nofile=65536:65536" on the ExecStart line
 # then systemctl daemon-reload and systemctl restart docker
 
+# default generator
+generator_tool="${GENERATOR_TOOL:-swagger}"
+
+# generator can be 'swagger' or 'openapi'
+if [ "$generator_tool" = "swagger" ]; then
+    docker_image="swaggerapi/swagger-codegen-cli-v3:3.0.68"
+    generator_flag="-l"
+else
+    # releases: https://github.com/OpenAPITools/openapi-generator/releases
+    generator_version="v7.13.0"
+    docker_image="openapitools/openapi-generator-cli:$generator_version"
+    generator_flag="-g"
+fi
 
 # the docker image used to generate the client code
 # pinning version to avoid unexpected bugs
-# releases: https://github.com/OpenAPITools/openapi-generator/releases
-generator_version="v7.13.0"
 docker_image="openapitools/openapi-generator-cli:$generator_version"
 # where to grab the definition file
 openapi_yaml_url="https://raw.githubusercontent.com/elabftw/elabftw/master/apidoc/v2/openapi.yaml"
@@ -24,17 +35,17 @@ function cleanup {
 # generate the lib from remote spec
 function generate {
     cleanup
-    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" -g python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" $generator_flag python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
 }
 
 function generate-html {
     cleanup
-    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" -g html2 -o /local/"$html" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" $generator_flag html2 -o /local/"$html" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
 }
 
 # don't use user/group ids in GH actions
 function generate-ci {
-    docker run --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" -g python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" $generator_flag python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
     # fix permissions
     sudo chown -R "$(id -u)":"$(id -gn)" "$lib"
 }
@@ -42,7 +53,7 @@ function generate-ci {
 # generate the lib from a local file in current directory
 function generate-from-local {
     cleanup
-    docker run --user "$(id -u)":"$(id -g)" --rm -v "${PWD}":/local "$docker_image" generate -i /local/openapi.yaml -g python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --user "$(id -u)":"$(id -g)" --rm -v "${PWD}":/local "$docker_image" generate -i /local/openapi.yaml $generator_flag python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
 }
 
 function venv {

--- a/helper.sh
+++ b/helper.sh
@@ -10,7 +10,9 @@ generator_tool="${GENERATOR_TOOL:-swagger}"
 # generator can be 'swagger' or 'openapi'
 # the docker image used to generate the client code
 if [ "$generator_tool" = "swagger" ]; then
-    docker_image="swaggerapi/swagger-codegen-cli-v3:3.0.68"
+    generator_lineage="v3"
+    generator_version="3.0.68"
+    docker_image="swaggerapi/swagger-codegen-cli-$generator_lineage:$generator_version"
     generator_flag="-l"
 else
     # releases: https://github.com/OpenAPITools/openapi-generator/releases

--- a/helper.sh
+++ b/helper.sh
@@ -8,6 +8,7 @@
 generator_tool="${GENERATOR_TOOL:-swagger}"
 
 # generator can be 'swagger' or 'openapi'
+# the docker image used to generate the client code
 if [ "$generator_tool" = "swagger" ]; then
     docker_image="swaggerapi/swagger-codegen-cli-v3:3.0.68"
     generator_flag="-l"
@@ -18,9 +19,6 @@ else
     generator_flag="-g"
 fi
 
-# the docker image used to generate the client code
-# pinning version to avoid unexpected bugs
-docker_image="openapitools/openapi-generator-cli:$generator_version"
 # where to grab the definition file
 openapi_yaml_url="https://raw.githubusercontent.com/elabftw/elabftw/master/apidoc/v2/openapi.yaml"
 # folder with the generated python code
@@ -35,17 +33,17 @@ function cleanup {
 # generate the lib from remote spec
 function generate {
     cleanup
-    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" $generator_flag python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" "$generator_flag" python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
 }
 
 function generate-html {
     cleanup
-    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" $generator_flag html2 -o /local/"$html" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --user "$(id -u)":"$(id -u)" --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" "$generator_flag" html2 -o /local/"$html" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
 }
 
 # don't use user/group ids in GH actions
 function generate-ci {
-    docker run --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" $generator_flag python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --rm -v "${PWD}":/local "$docker_image" generate -i "$openapi_yaml_url" "$generator_flag" python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
     # fix permissions
     sudo chown -R "$(id -u)":"$(id -gn)" "$lib"
 }
@@ -53,7 +51,7 @@ function generate-ci {
 # generate the lib from a local file in current directory
 function generate-from-local {
     cleanup
-    docker run --user "$(id -u)":"$(id -g)" --rm -v "${PWD}":/local "$docker_image" generate -i /local/openapi.yaml $generator_flag python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
+    docker run --user "$(id -u)":"$(id -g)" --rm -v "${PWD}":/local "$docker_image" generate -i /local/openapi.yaml "$generator_flag" python -o /local/"$lib" -c /local/config.json --git-user-id elabftw --git-repo-id elabapi-python
 }
 
 function venv {


### PR DESCRIPTION
Use swagger-codegen as the default generator for the library.
Allow using the openapi-generator with either:
- Export the variable
```bash
export GENERATOR_TOOL=openapi
./helper.sh generate
```
- One liner
```bash
GENERATOR_TOOL=openapi ./helper.sh generate
```