### PR TITLE
ci: pin GitHub Actions to SHA-pinned commit versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2
       with:
         python-version: '3.x'
     - name: Install pypa/build
@@ -26,7 +26,7 @@ jobs:
       run: |
         bash helper.sh build-ci
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Pin github actions to SHA-pinned commit versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions versions in the automated publishing workflow to specific commit revisions, enhancing stability and security of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->